### PR TITLE
Fix command line parsing

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -555,7 +555,7 @@ main(int argc, char *argv[])
 
 	struct poptOption options[] = {
 		{.argInfo = POPT_ARG_INTL_DOMAIN,
-		 .descrip = "pesign" },
+		 .arg = "pesign" },
 		{.longName = "token",
 		 .shortName = 't',
 		 .argInfo = POPT_ARG_STRING|POPT_ARGFLAG_SHOW_DEFAULT,

--- a/src/efikeygen.c
+++ b/src/efikeygen.c
@@ -486,7 +486,7 @@ int main(int argc, char *argv[])
 	poptContext optCon;
 	struct poptOption options[] = {
 		{.argInfo = POPT_ARG_INTL_DOMAIN,
-		 .descrip = "pesign" },
+		 .arg = "pesign" },
 		/* global nss-ish things */
 		{.longName = "dbdir",
 		 .shortName = 'd',

--- a/src/efisiglist.c
+++ b/src/efisiglist.c
@@ -126,7 +126,7 @@ main(int argc, char *argv[])
 
 	struct poptOption options[] = {
 		{.argInfo = POPT_ARG_INTL_DOMAIN,
-		 .descrip = "pesign" },
+		 .arg = "pesign" },
 		{.longName = "infile",
 		 .shortName = 'i',
 		 .argInfo = POPT_ARG_STRING,

--- a/src/pesigcheck.c
+++ b/src/pesigcheck.c
@@ -214,7 +214,7 @@ main(int argc, char *argv[])
 	poptContext optCon;
 	struct poptOption options[] = {
 		{.argInfo = POPT_ARG_INTL_DOMAIN,
-		 .descrip = "pesign" },
+		 .arg = "pesign" },
 		{.longName = "dbfile",
 		 .shortName = 'D',
 		 .argInfo = POPT_ARG_CALLBACK|POPT_CBFLAG_POST,


### PR DESCRIPTION
The gettext translation domain should be passed as .arg, not .descrip,
otherwise popt won't process any of the command line options (it stops
looping over the struct poptOption array when an entry has unset
longName, shortName and arg).

Signed-off-by: Julien Cristau <jcristau@debian.org>