### PR TITLE
Fix description of --ascii-armor option in manpage

### DIFF
--- a/src/pesign.1
+++ b/src/pesign.1
@@ -81,7 +81,7 @@ Export the public key specified by \-\-certificate to \fIoutkey\fR
 Export the certificate specified by \-\-certificate to \fIoutcert\fR
 
 .TP
-\fB-\-ascii\fR
+\fB-\-ascii\-armor\fR
 Use ascii armoring on exported certificates.
 
 .TP


### PR DESCRIPTION
The --ascii option does not exist.
