### PR TITLE
efisiglist: Correct the argument for the translation domain

### DIFF
--- a/src/efisiglist.c
+++ b/src/efisiglist.c
@@ -126,7 +126,7 @@ main(int argc, char *argv[])
 
 	struct poptOption options[] = {
 		{.argInfo = POPT_ARG_INTL_DOMAIN,
-		 .descrip = "pesign" },
+		 .arg = "pesign" },
 		{.longName = "infile",
 		 .shortName = 'i',
 		 .argInfo = POPT_ARG_STRING,


### PR DESCRIPTION
The translation domain of popt was mistakenly set in descrip, and this
made all the options unusable.

Signed-off-by: Gary Lin <glin@suse.com>