### PR TITLE
Switch pesign client to also accept token/cert macros

### DIFF
--- a/src/macros.pesign
+++ b/src/macros.pesign
@@ -41,11 +41,11 @@
                  --certdir ${nss} -c signer %{-o}			\
       rm -rf ${sattrs} ${sattrs}.sig ${nss}				\
     elif [ -S /var/run/pesign/socket ]; then				\
-      %{_pesign_client} -t "OpenSC Card (Fedora Signer)"		\\\
-                        -c "/CN=Fedora Secure Boot Signer"		\\\
+      %{_pesign_client} -t %{__pesign_token}				\\\
+                        -c %{__pesign_cert}				\\\
                         %{-i} %{-o} %{-e} %{-s} %{-C}			\
     else								\
-      %{_pesign} %{__pesign_token} -c %{__pesign_cert}			\\\
+      %{_pesign} -t %{__pesign_token} -c %{__pesign_cert}		\\\
 		 --certdir ${_pesign_nssdir}				\\\
                  %{-i} %{-o} %{-e} %{-s} %{-C}				\
     fi									\


### PR DESCRIPTION
Right now the token 'OpenSC Card (Fedora Signer)' and cert '/CN=Fedora Secure Boot Signer' are hard coded within the pesign macros for the pesign client.

Users who want to use pesign to sign their own items cannot use the pesign macro for socket based fall through without editing the macro.  As a result users either have to edit the macro manually or use something other than the pesign client.

This patch allows _pesign_client to take rpm macros for the cert/token.