### PR TITLE
pesign: Fix option longname typo

### DIFF
--- a/src/pesign.c
+++ b/src/pesign.c
@@ -438,7 +438,7 @@ main(int argc, char *argv[])
 		 .arg = &ctxp->outfile,
 		 .descrip = "specify output file",
 		 .argDescrip = "<outfile>" },
-		{.longName = "certficate",
+		{.longName = "certificate",
 		 .shortName = 'c',
 		 .argInfo = POPT_ARG_STRING,
 		 .arg = &certname,

--- a/src/pesign.popt
+++ b/src/pesign.popt
@@ -1,2 +1,3 @@
 pesign alias --cert --certificate
+pesign alias --certficate --certificate
 pesign alias --daemon --daemonize


### PR DESCRIPTION
All of the documentation uses the correct spelling.  It was just
the actual program that had this problem.

In case there are any users with scripts utilizing the misspelled
option, a compatibility alias has been added to the popt file.