### PR TITLE
pesigcheck: Verify with the cert as an object signer

### DIFF
--- a/src/certdb.c
+++ b/src/certdb.c
@@ -339,7 +339,7 @@ check_cert(pesigcheck_context *ctx, SECItem *sig, efi_guid_t *sigtype,
 	}
 	/* Verify the signature */
 	result = SEC_PKCS7VerifyDetachedSignatureAtTime(cinfo,
-						certUsageSSLServer,
+						certUsageObjectSigner,
 						digest, HASH_AlgSHA256,
 						PR_FALSE, atTime);
 	if (!result) {


### PR DESCRIPTION
It seems wrong to expect an SSL server certificate for verifying UEFI signatures.  Should this be changed to `objectSigner` usage?